### PR TITLE
Add pathParametersLin to iiwa_ros

### DIFF
--- a/iiwa_ros/CMakeLists.txt
+++ b/iiwa_ros/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(${PROJECT_NAME}
 	src/iiwa_ros.cpp
 	src/smart_servo_service.cpp
 	src/path_parameters_service.cpp
+    src/path_parameters_lin_service.cpp
 	src/time_to_destination_service.cpp
 )
 

--- a/iiwa_ros/include/iiwa_ros/iiwa_ros.h
+++ b/iiwa_ros/include/iiwa_ros/iiwa_ros.h
@@ -40,6 +40,7 @@
 #include <iiwa_msgs/JointTorque.h>
 #include <iiwa_msgs/JointVelocity.h>
 #include <iiwa_ros/path_parameters_service.h>
+#include <iiwa_ros/path_parameters_lin_service.h>
 #include <iiwa_ros/smart_servo_service.h>
 #include <iiwa_ros/time_to_destination_service.h>
 #include <ros/ros.h>
@@ -260,6 +261,16 @@ public:
   }
 
   /**
+   * @brief Returns the object that allows to call the timeToDestination service.
+   *
+   * @return iiwa_ros::PathParametersService
+   */
+  PathParametersLinService getPathParametersLinService()
+  {
+    return path_parameters_lin_service_;
+  }
+
+  /**
    * @brief Returns the object that allows to call the setPathParameters service.
    *
    * @return iiwa_ros::TimeToDestinationService
@@ -328,6 +339,7 @@ private:
 
   SmartServoService smart_servo_service_;
   PathParametersService path_parameters_service_;
+  PathParametersLinService path_parameters_lin_service_;
   TimeToDestinationService time_to_destination_service_;
 };
 }

--- a/iiwa_ros/include/iiwa_ros/path_parameters_lin_service.h
+++ b/iiwa_ros/include/iiwa_ros/path_parameters_lin_service.h
@@ -28,50 +28,42 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <iiwa_ros/time_to_destination_service.h>
+#pragma once
+
+#include <iiwa_msgs/SetPathParametersLin.h>
+#include <iiwa_ros/iiwa_services.hpp>
 
 namespace iiwa_ros
 {
-TimeToDestinationService::TimeToDestinationService() : iiwaServices<iiwa_msgs::TimeToDestination>()
+class PathParametersLinService : public iiwaServices<iiwa_msgs::SetPathParametersLin>
 {
-}
+public:
+  PathParametersLinService();
 
-TimeToDestinationService::TimeToDestinationService(const std::string& service_name, const bool verbose)
-  : iiwaServices<iiwa_msgs::TimeToDestination>(service_name, verbose)
-{
-}
+  /**
+   * @brief ...
+   *
+   * @param service_name ...
+   * @param verbose ...
+   */
+  PathParametersLinService(const std::string& service_name, const bool verbose = true);
+  /**
+   * @brief ...
+   *
+   * @param max_cartesian_velocity ...
+   * @return bool
+   */
+  bool setMaxCartesianVelocity(const geometry_msgs::Twist max_cartesian_velocity);
 
-double TimeToDestinationService::getTimeToDestination()
-{
-  if (service_ready_)
-  {
-    if (callService())
-    {
-      return time_to_destination_;
-    }
-    else
-    {
-      return -999;  // It cannot return -1 since it might be a meaningfull result.
-    }
-  }
-  ROS_ERROR_STREAM("The service client was not intialized yet.");
-}
+  /**
+   * @brief ...
+   *
+   * @param max_cartesian_velocity ...
+   * @return bool
+   */
+  bool setPathParametersLin(const geometry_msgs::Twist max_cartesian_velocity);
 
-bool TimeToDestinationService::callService()
-{
-  if (client_.call(config_))
-  {
-    if (verbose_)
-    {
-        ROS_DEBUG_STREAM(ros::this_node::getName() << ": " << service_name_ << " successfully called.");
-    }
-    time_to_destination_ = config_.response.remaining_time;
-    return true;
-  }
-  else if (verbose_)
-  {
-    ROS_ERROR_STREAM(service_name_ << " could not be called");
-  }
-  return false;
-}
+protected:
+  virtual bool callService();
+};
 }

--- a/iiwa_ros/src/iiwa_ros.cpp
+++ b/iiwa_ros/src/iiwa_ros.cpp
@@ -60,6 +60,7 @@ void iiwaRos::init()
 
   smart_servo_service_.setServiceName("configuration/configureSmartServo");
   path_parameters_service_.setServiceName("configuration/pathParameters");
+  path_parameters_lin_service_.setServiceName("configuration/pathParametersLin");
   time_to_destination_service_.setServiceName("state/timeToDestination");
 }
 

--- a/iiwa_ros/src/path_parameters_lin_service.cpp
+++ b/iiwa_ros/src/path_parameters_lin_service.cpp
@@ -28,50 +28,52 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <iiwa_ros/time_to_destination_service.h>
+#include <iiwa_ros/path_parameters_lin_service.h>
 
 namespace iiwa_ros
 {
-TimeToDestinationService::TimeToDestinationService() : iiwaServices<iiwa_msgs::TimeToDestination>()
+PathParametersLinService::PathParametersLinService() : iiwaServices<iiwa_msgs::SetPathParametersLin>()
 {
 }
 
-TimeToDestinationService::TimeToDestinationService(const std::string& service_name, const bool verbose)
-  : iiwaServices<iiwa_msgs::TimeToDestination>(service_name, verbose)
+PathParametersLinService::PathParametersLinService(const std::string& service_name, const bool verbose)
+  : iiwaServices<iiwa_msgs::SetPathParametersLin>(service_name, verbose)
 {
 }
 
-double TimeToDestinationService::getTimeToDestination()
+bool PathParametersLinService::callService()
 {
   if (service_ready_)
   {
-    if (callService())
+    if (client_.call(config_))
     {
-      return time_to_destination_;
+      if (!config_.response.success && verbose_)
+      {
+        service_error_ = config_.response.error;
+        ROS_ERROR_STREAM(service_name_ << " failed, Java error: " << service_error_);
+      }
+      else if (verbose_)
+      {
+        ROS_INFO_STREAM(ros::this_node::getName() << ":" << service_name_ << " successfully called.");
+      }
     }
-    else
+    else if (verbose_)
     {
-      return -999;  // It cannot return -1 since it might be a meaningfull result.
+      ROS_ERROR_STREAM(service_name_ << " could not be called");
     }
+    return config_.response.success;
   }
   ROS_ERROR_STREAM("The service client was not intialized yet.");
 }
 
-bool TimeToDestinationService::callService()
+bool PathParametersLinService::setPathParametersLin(const geometry_msgs::Twist max_cartesian_velocity)
 {
-  if (client_.call(config_))
-  {
-    if (verbose_)
-    {
-        ROS_DEBUG_STREAM(ros::this_node::getName() << ": " << service_name_ << " successfully called.");
-    }
-    time_to_destination_ = config_.response.remaining_time;
-    return true;
-  }
-  else if (verbose_)
-  {
-    ROS_ERROR_STREAM(service_name_ << " could not be called");
-  }
-  return false;
+  setPathParametersLin(max_cartesian_velocity);
 }
+
+bool PathParametersLinService::setMaxCartesianVelocity(const geometry_msgs::Twist max_cartesian_velocity)
+{
+  setPathParametersLin(max_cartesian_velocity);
+}
+
 }


### PR DESCRIPTION
This adds the new pathParametersLin service to iiwa_ros. The format is identical to the path_parameters_service. I only trimmed it, changed the input parameters and updated the other connected files so that it builds.

The underlying service is bugged, so it's not tested, but it should work.