### PR TITLE
Expanded supported version range

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## IIWA STACK
 ROS Indigo/Kinetic metapackage for the KUKA LBR IIWA R800/R820 (7/14 Kg).
 
-**Current version : v-1.2.0 for Sunrise 1.11**    
+**Current version : v-1.2.0 for Sunrise 1.10 - 1.14**
 [Using a previous version of Sunrise?](https://github.com/SalvoVirga/iiwa_stack/wiki/FAQ#which-version-of-sunriseossunrise-workbench-is-supported)    
 
 [![Build Status](https://travis-ci.org/IFL-CAMP/iiwa_stack.svg?branch=master)](https://travis-ci.org/IFL-CAMP/iiwa_stack)


### PR DESCRIPTION
I've tested the latest version on real arms with versions 1.10 - 1.14 (I missed 1.12) and it worked as expected.

Also, I have a minor suggestion for the wiki.  Instead of forcing ROS to use IPs in step 6 of roscore_setup, you can use Notepad or Wordpad as administrator when setting up the KONI interface in the controller to edit C:\Windows\System32\drivers\etc\hosts. Adding the hostname of the master and IP makes working with the ROS master on DHCP networks much easier