### PR TITLE
Added missing file (from development)

### DIFF
--- a/iiwa_msgs/srv/SetPathParametersLin.srv
+++ b/iiwa_msgs/srv/SetPathParametersLin.srv
@@ -1,0 +1,4 @@
+geometry_msgs/Twist max_cartesian_velocity
+---
+bool success
+string error


### PR DESCRIPTION
Hi,

just noticed that the `/iiwa/configuration/pathParametersLin` service exists on current masters sunrise side, but the message is missing in the iiwa_msgs directory.

Cheers,

Arne