### PR TITLE
Configuration using the Teach Pendant

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,66 @@
+---
+BasedOnStyle:  Google
+AccessModifierOffset: -2
+ConstructorInitializerIndentWidth: 2
+AlignEscapedNewlinesLeft: false
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakTemplateDeclarations: true
+AlwaysBreakBeforeMultilineStrings: false
+BreakBeforeBinaryOperators: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: true
+BinPackParameters: true
+ColumnLimit:    120
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+DerivePointerBinding: false
+PointerBindsToType: true
+ExperimentalAutoDetectBinPacking: false
+IndentCaseLabels: true
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 60
+PenaltyBreakString: 1
+PenaltyBreakFirstLessLess: 1000
+PenaltyExcessCharacter: 1000
+PenaltyReturnTypeOnItsOwnLine: 90
+SpacesBeforeTrailingComments: 2
+Cpp11BracedListStyle: true
+Standard:        Auto
+IndentWidth:     2
+TabWidth:        2
+UseTab:          Never
+IndentFunctionDeclarationAfterType: false
+SpacesInParentheses: false
+SpacesInAngles:  false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpaceAfterControlStatementKeyword: true
+SpaceBeforeAssignmentOperators: true
+ContinuationIndentWidth: 4
+SortIncludes: false
+SpaceAfterCStyleCast: false
+
+# Configure each individual brace in BraceWrapping
+BreakBeforeBraces: Custom
+
+# Control of individual brace wrapping cases
+BraceWrapping: {
+    AfterClass: 'true'
+    AfterControlStatement: 'true'
+    AfterEnum : 'true'
+    AfterFunction : 'true'
+    AfterNamespace : 'true'
+    AfterStruct : 'true'
+    AfterUnion : 'true'
+    BeforeCatch : 'true'
+    BeforeElse : 'true'
+    IndentBraces : 'false'
+}
+...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,117 +1,18 @@
-# Generic .travis.yml file for running continuous integration on Travis-CI for
-# any ROS package.
-#
-# Available here:
-#   - http://felixduvallet.github.io/ros-travis-integration
-#   - https://github.com/felixduvallet/ros-travis-integration
-#
-# This installs ROS on a clean Travis-CI virtual machine, creates a ROS
-# workspace, resolves all listed dependencies, and sets environment variables
-# (setup.bash). Then, it compiles the entire ROS workspace (ensuring there are
-# no compilation errors), and runs all the tests. If any of the compilation/test
-# phases fail, the build is marked as a failure.
-#
-# We handle two types of package dependencies:
-#   - packages (ros and otherwise) available through apt-get. These are installed
-#     using rosdep, based on the information in the ROS package.xml.
-#   - dependencies that must be checked out from source. These are handled by
-#     'wstool', and should be listed in a file named dependencies.rosinstall.
-#
-# There are two variables you may want to change:
-#   - ROS_DISTRO (default is indigo). Note that packages must be available for
-#     ubuntu 14.04 trusty.
-#   - ROSINSTALL_FILE (default is dependencies.rosinstall inside the repo
-#     root). This should list all necessary repositories in wstool format (see
-#     the ros wiki). If the file does not exists then nothing happens.
-#
-# See the README.md for more information.
-#
-# Author: Felix Duvallet <felixd@gmail.com>
-
-# NOTE: The build lifecycle on Travis.ci is something like this:
-#    before_install
-#    install
-#    before_script
-#    script
-#    after_success or after_failure
-#    after_script
-#    OPTIONAL before_deploy
-#    OPTIONAL deploy
-#    OPTIONAL after_deploy
-
-################################################################################
-
-# Use ubuntu trusty (14.04) with sudo privileges.
-dist: trusty
 sudo: required
-language:
-  - generic
-cache:
-  - apt
 
-# Configuration variables. All variables are global now, but this can be used to
-# trigger a build matrix for different ROS distributions if desired.
+language: generic
+
+services:
+  - docker
+
 env:
   global:
-    - ROS_DISTRO=indigo
-    - ROS_CI_DESKTOP="`lsb_release -cs`"  # e.g. [precise|trusty|...]
-    - CI_SOURCE_PATH=$(pwd)
-    - ROSINSTALL_FILE=$CI_SOURCE_PATH/dependencies.rosinstall
-    - CATKIN_OPTIONS=$CI_SOURCE_PATH/catkin.options
-    - ROS_PARALLEL_JOBS='-j8 -l6'
+    - toolset_branch: master
+    - server_type: travis
+    - ros_release_name: kinetic
+    - ubuntu_version_name: xenial
+    - used_modules: check_cache,build
+    - remote_shell_script: 'https://raw.githubusercontent.com/shadow-robot/sr-build-tools/$toolset_branch/bin/sr-run-ci-build.sh'
 
-################################################################################
-
-# Install system dependencies, namely a very barebones ROS setup.
-before_install:
-  - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
-  - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
-  - sudo apt-get update -qq
-  - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin
-  - source /opt/ros/$ROS_DISTRO/setup.bash
-  # Prepare rosdep to install dependencies.
-  - sudo rosdep init
-  - rosdep update
-
-# Create a catkin workspace with the package under integration.
-install:
-  - mkdir -p ~/catkin_ws/src
-  - cd ~/catkin_ws/src
-  - catkin_init_workspace
-  # Create the devel/setup.bash (run catkin_make with an empty workspace) and
-  # source it to set the path variables.
-  - cd ~/catkin_ws
-  - catkin_make
-  - source devel/setup.bash
-  # Add the package under integration to the workspace using a symlink.
-  - cd ~/catkin_ws/src
-  - ln -s $CI_SOURCE_PATH .
-
-# Install all dependencies, using wstool and rosdep.
-# wstool looks for a ROSINSTALL_FILE defined in the environment variables.
-before_script:
-  # source dependencies: install using wstool.
-  - cd ~/catkin_ws/src
-  - wstool init
-  - if [[ -f $ROSINSTALL_FILE ]] ; then wstool merge $ROSINSTALL_FILE ; fi
-  - wstool up
-  # package depdencies: install using rosdep.
-  - cd ~/catkin_ws
-  - rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
-
-# Compile and test (fail if any step fails). If the CATKIN_OPTIONS file exists,
-# use it as an argument to catkin_make, for example to blacklist certain
-# packages.
-#
-# NOTE on testing: `catkin_make run_tests` will show the output of the tests
-# (gtest, nosetest, etc..) but always returns 0 (success) even if a test
-# fails. On the other hand, `catkin_make test` aggregates all results, but
-# returns non-zero when a test fails (which notifies Travis the build
-# failed). This is why we run both.
 script:
-  - source /opt/ros/$ROS_DISTRO/setup.bash
-  - cd ~/catkin_ws
-  - catkin_make $( [ -f $CATKIN_OPTIONS ] && cat $CATKIN_OPTIONS )
-  # Run the tests, ensuring the path is set correctly.
-  - source devel/setup.bash
-  - catkin_make run_tests && catkin_make test
+  - curl -s "$( echo "$remote_shell_script" | sed 's/#/%23/g' )" | bash -x /dev/stdin "$toolset_branch" $server_type $used_modules

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ ROS Indigo/Kinetic metapackage for the KUKA LBR IIWA R800/R820 (7/14 Kg).
 **Current version : v-1.2.0 for Sunrise 1.11**    
 [Using a previous version of Sunrise?](https://github.com/SalvoVirga/iiwa_stack/wiki/FAQ#which-version-of-sunriseossunrise-workbench-is-supported)    
 
-[![Build Status](https://travis-ci.org/SalvoVirga/iiwa_stack.svg?branch=master)](https://travis-ci.org/SalvoVirga/iiwa_stack)
-___
+[![Build Status](https://travis-ci.org/IFL-CAMP/iiwa_stack.svg?branch=master)](https://travis-ci.org/IFL-CAMP/iiwa_stack)
+
 ### Features
 - Native ROSJava nodes running on the robot as a Sunrise RoboticApplication: supports ROS parameters, topics, services, etc.
 - Integration of KUKA's SmartServo motions:

--- a/iiwa/package.xml
+++ b/iiwa/package.xml
@@ -14,9 +14,8 @@
   <run_depend>iiwa_description</run_depend>
   <run_depend>iiwa_gazebo</run_depend>
   <run_depend>iiwa_hw</run_depend>
-  <run_depend>iiwa_launch</run_depend>
   <run_depend>iiwa_moveit</run_depend>
-  <run_depend>iiwa_msg</run_depend>
+  <run_depend>iiwa_msgs</run_depend>
   <run_depend>iiwa_ros</run_depend>
   
   <export>

--- a/iiwa_control/launch/iiwa_control.launch
+++ b/iiwa_control/launch/iiwa_control.launch
@@ -8,16 +8,15 @@
     <arg name="controllers" default="joint_state_controller pos_joint_trajectory_controller"/>
     <arg name="robot_name" default="iiwa" />
     <arg name="model" default="iiwa7" />
-    <arg name="joint_state_frequency" default="100" />
-    <arg name="robot_state_frequency" default="100" />
+    <arg name="joint_state_frequency" default="500" />
+    <arg name="robot_state_frequency" default="500" />
     
     <!-- Loads joint controller configurations from YAML file to parameter server -->
     <rosparam file="$(find iiwa_control)/config/iiwa_control.yaml" command="load" />
     <param name="/$(arg robot_name)/joint_state_controller/publish_rate" value="$(arg joint_state_frequency)" />
     
     <!-- Loads the controllers -->
-    <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-          output="screen" args="$(arg controllers) --shutdown-timeout 2" />
+    <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="$(arg controllers)" />
     
     <!-- Converts joint states to TF transforms for rviz, etc -->
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"

--- a/iiwa_hw/include/iiwa_hw.h
+++ b/iiwa_hw/include/iiwa_hw.h
@@ -88,8 +88,7 @@ public:
    * Returns the joint's type, lower position limit, upper position limit, and effort limit.
    */
   void registerJointLimits(const std::string& joint_name, const hardware_interface::JointHandle& joint_handle,
-                           const urdf::Model* const urdf_model, double* const lower_limit, double* const upper_limit,
-                           double* const effort_limit);
+                           const urdf::Model& urdf_model, double lower_limit, double upper_limit, double effort_limit);
 
   /**
    * \brief Reads the current robot state via the IIWARos interfae and sends the values to the IIWA device struct.
@@ -104,12 +103,12 @@ public:
   /**
    * \brief Retuns the ros::Rate object to control the receiving/sending rate.
    */
-  ros::Rate getRate();
+  ros::Rate getRate() const;
 
   /**
    * \brief Retuns the current frequency used by a ros::Rate object to control the receiving/sending rate.
    */
-  double getFrequency();
+  double getFrequency() const;
 
   /**
    * \brief Set the frequency to be used by a ros::Rate object to control the receiving/sending rate.
@@ -180,7 +179,7 @@ private:
   joint_limits_interface::PositionJointSaturationInterface pj_sat_interface_;
   joint_limits_interface::PositionJointSoftLimitsInterface pj_limits_interface_;
 
-  boost::shared_ptr<IIWA_HW::IIWA_device> device_; /**< IIWA device. */
+  std::shared_ptr<IIWA_HW::IIWA_device> device_; /**< IIWA device. */
 
   /** Objects to control send/receive rate. */
   ros::Time timer_;

--- a/iiwa_hw/include/iiwa_hw.h
+++ b/iiwa_hw/include/iiwa_hw.h
@@ -74,11 +74,6 @@ public:
   IIWA_HW(ros::NodeHandle nh);
 
   /**
-   * Destructor
-   */
-  virtual ~IIWA_HW();
-
-  /**
    * \brief Initializes the IIWA device struct and all the hardware and joint limits interfaces needed.
    *
    * A joint state handle is created and linked to the current joint state of the IIWA robot.
@@ -109,7 +104,7 @@ public:
   /**
    * \brief Retuns the ros::Rate object to control the receiving/sending rate.
    */
-  ros::Rate* getRate();
+  ros::Rate getRate();
 
   /**
    * \brief Retuns the current frequency used by a ros::Rate object to control the receiving/sending rate.
@@ -121,9 +116,24 @@ public:
    */
   void setFrequency(double frequency);
 
-  /** Structure for a lbr iiwa, joint handles, etc */
+  /** Structure for a LBR iiwa, joint handles, etc */
   struct IIWA_device
   {
+    IIWA_device()
+      : joint_names(7)
+      , joint_lower_limits(7)
+      , joint_upper_limits(7)
+      , joint_effort_limits(7)
+      , joint_position(7)
+      , joint_position_prev(7)
+      , joint_velocity(7)
+      , joint_effort(7)
+      , joint_position_command(7)
+      , joint_stiffness_command(7)
+      , joint_damping_command(7)
+      , joint_effort_command(7)
+    {
+    }
     /** Vector containing the name of the joints - taken from yaml file */
     std::vector<std::string> joint_names;
 
@@ -134,44 +144,21 @@ public:
     /**< Joint state and commands */
     std::vector<double> joint_position, joint_position_prev, joint_velocity, joint_effort, joint_position_command,
         joint_stiffness_command, joint_damping_command, joint_effort_command;
-
-    /**
-     * \brief Initialze vectors
-     */
-    void init()
-    {
-      joint_position.resize(IIWA_JOINTS);
-      joint_position_prev.resize(IIWA_JOINTS);
-      joint_velocity.resize(IIWA_JOINTS);
-      joint_effort.resize(IIWA_JOINTS);
-      joint_position_command.resize(IIWA_JOINTS);
-      joint_effort_command.resize(IIWA_JOINTS);
-      joint_stiffness_command.resize(IIWA_JOINTS);
-      joint_damping_command.resize(IIWA_JOINTS);
-
-      joint_lower_limits.resize(IIWA_JOINTS);
-      joint_upper_limits.resize(IIWA_JOINTS);
-      joint_effort_limits.resize(IIWA_JOINTS);
-    }
-
     /**
      * \brief Reset values of the vectors
      */
     void reset()
     {
-      for (int j = 0; j < IIWA_JOINTS; ++j)
-      {
-        joint_position[j] = 0.0;
-        joint_position_prev[j] = 0.0;
-        joint_velocity[j] = 0.0;
-        joint_effort[j] = 0.0;
-        joint_position_command[j] = 0.0;
-        joint_effort_command[j] = 0.0;
+      joint_position.clear();
+      joint_position_prev.clear();
+      joint_velocity.clear();
+      joint_effort.clear();
+      joint_position_command.clear();
+      joint_effort_command.clear();
 
-        // set default values for these two for now
-        joint_stiffness_command[j] = 0.0;
-        joint_damping_command[j] = 0.0;
-      }
+      // set default values for these two for now
+      joint_stiffness_command.clear();
+      joint_damping_command.clear();
     }
   };
 
@@ -197,8 +184,8 @@ private:
 
   /** Objects to control send/receive rate. */
   ros::Time timer_;
-  ros::Rate* loop_rate_;
   double control_frequency_;
+  ros::Rate loop_rate_;
 
   iiwa_ros::iiwaRos iiwa_ros_conn_;
   iiwa_msgs::JointPosition joint_position_;
@@ -211,27 +198,3 @@ private:
 
   std::vector<std::string> interface_type_; /**< Contains the strings defining the possible hardware interfaces. */
 };
-
-template <typename T>
-void iiwaMsgsJointToVector(const iiwa_msgs::JointQuantity& ax, std::vector<T>& v)
-{
-  v[0] = ax.a1;
-  v[1] = ax.a2;
-  v[2] = ax.a3;
-  v[3] = ax.a4;
-  v[4] = ax.a5;
-  v[5] = ax.a6;
-  v[6] = ax.a7;
-}
-
-template <typename T>
-void vectorToIiwaMsgsJoint(const std::vector<T>& v, iiwa_msgs::JointQuantity& ax)
-{
-  ax.a1 = v[0];
-  ax.a2 = v[1];
-  ax.a3 = v[2];
-  ax.a4 = v[3];
-  ax.a5 = v[4];
-  ax.a6 = v[5];
-  ax.a7 = v[6];
-}

--- a/iiwa_hw/src/iiwa_hw.cpp
+++ b/iiwa_hw/src/iiwa_hw.cpp
@@ -52,15 +52,16 @@ IIWA_HW::IIWA_HW(ros::NodeHandle nh)
   , control_frequency_(DEFAULT_CONTROL_FREQUENCY)
   , loop_rate_(control_frequency_)
   , interface_type_{"PositionJointInterface", "EffortJointInterface", "VelocityJointInterface"}
+  , device_(std::make_shared<IIWA_HW::IIWA_device>())
 {
 }
 
-ros::Rate IIWA_HW::getRate()
+ros::Rate IIWA_HW::getRate() const
 {
   return loop_rate_;
 }
 
-double IIWA_HW::getFrequency()
+double IIWA_HW::getFrequency() const
 {
   return control_frequency_;
 }
@@ -73,17 +74,9 @@ void IIWA_HW::setFrequency(double frequency)
 
 bool IIWA_HW::start()
 {
-  // construct a new IIWA device (interface and state storage)
-  device_.reset(new IIWA_HW::IIWA_device());
-
   // TODO : make use of this
-  // get inteface param or give default values
+  // Get inteface param or give default values
   nh_.param("interface", interface_, std::string("PositionJointInterface"));
-
-  /* TODO
-   * nh_.param("move_group", movegroup_name_, "arm");
-   * group(movegroup_name_);
-   */
 
   // TODO: use transmission configuration to get names directly from the URDF model
   if (ros::param::get("joints", device_->joint_names))
@@ -108,94 +101,93 @@ bool IIWA_HW::start()
 
   iiwa_ros_conn_.init();
 
-  // general joint to store information
-  boost::shared_ptr<const urdf::Joint> joint;
-
-  // create joint handles given the list
+  // Create joint handles given the list
   for (int i = 0; i < IIWA_JOINTS; ++i)
   {
     ROS_INFO_STREAM("Handling joint: " << device_->joint_names[i]);
 
-    // get current joint configuration
-    joint = urdf_model_.getJoint(device_->joint_names[i]);
-    if (!joint.get())
+    // Get current joint configuration
+    auto joint = urdf_model_.getJoint(device_->joint_names[i]).get();
+    if (joint == nullptr)
     {
       ROS_ERROR_STREAM("The specified joint " << device_->joint_names[i]
-                                              << " can't be found in the URDF model. "
-                                                 "Check that you loaded an URDF model in the robot description, or "
-                                                 "that you spelled correctly the joint name.");
+                                              << " can't be found in the URDF model. Check that you loaded an URDF "
+                                                 "model in the robot description, or that you spelled correctly "
+                                                 "the joint name.");
       throw std::runtime_error("Wrong joint name specification");
     }
 
-    // joint state handle
-
+    // Joint state handle.
     hardware_interface::JointStateHandle state_handle(device_->joint_names[i], &(device_->joint_position[i]),
                                                       &(device_->joint_velocity[i]), &(device_->joint_effort[i]));
-
     state_interface_.registerHandle(state_handle);
 
-    // position command handle
+    // Position command handle
     hardware_interface::JointHandle position_joint_handle = hardware_interface::JointHandle(
         state_interface_.getHandle(device_->joint_names[i]), &device_->joint_position_command[i]);
-
     position_interface_.registerHandle(position_joint_handle);
 
-    // effort command handle
+    // Effort command handle
     hardware_interface::JointHandle joint_handle = hardware_interface::JointHandle(
         state_interface_.getHandle(device_->joint_names[i]), &device_->joint_effort_command[i]);
-
     effort_interface_.registerHandle(joint_handle);
 
-    registerJointLimits(device_->joint_names[i], joint_handle, &urdf_model_, &device_->joint_lower_limits[i],
-                        &device_->joint_upper_limits[i], &device_->joint_effort_limits[i]);
+    registerJointLimits(device_->joint_names[i], joint_handle, urdf_model_, device_->joint_lower_limits[i],
+                        device_->joint_upper_limits[i], device_->joint_effort_limits[i]);
   }
 
   ROS_INFO("Register state and effort interfaces");
 
-  // TODO: CHECK
-  // register ros-controls interfaces
-  this->registerInterface(&state_interface_);
-  this->registerInterface(&effort_interface_);
-  this->registerInterface(&position_interface_);
+  // Register ros-controls interfaces.
+  registerInterface(&state_interface_);
+  registerInterface(&effort_interface_);
+  registerInterface(&position_interface_);
 
   return true;
 }
 
 void IIWA_HW::registerJointLimits(const std::string& joint_name, const hardware_interface::JointHandle& joint_handle,
-                                  const urdf::Model* const urdf_model, double* const lower_limit,
-                                  double* const upper_limit, double* const effort_limit)
+                                  const urdf::Model& urdf_model, double lower_limit, double upper_limit,
+                                  double effort_limit)
 {
-  *lower_limit = -std::numeric_limits<double>::max();
-  *upper_limit = std::numeric_limits<double>::max();
-  *effort_limit = std::numeric_limits<double>::max();
+  lower_limit = -std::numeric_limits<double>::max();
+  upper_limit = std::numeric_limits<double>::max();
+  effort_limit = std::numeric_limits<double>::max();
 
   joint_limits_interface::JointLimits limits;
-  bool has_limits = false;
   joint_limits_interface::SoftJointLimits soft_limits;
-  bool has_soft_limits = false;
+  bool has_limits{false}, has_soft_limits{false};
 
-  if (urdf_model != NULL)
+  auto urdf_joint = urdf_model.getJoint(joint_name);
+
+  if (urdf_joint != nullptr)
   {
-    const boost::shared_ptr<const urdf::Joint> urdf_joint = urdf_model->getJoint(joint_name);
-
-    if (urdf_joint != NULL)
+    // Get limits from the URDF file.
+    if (joint_limits_interface::getJointLimits(urdf_joint, limits))
     {
-      // Get limits from the URDF file.
-      if (joint_limits_interface::getJointLimits(urdf_joint, limits)) has_limits = true;
+      has_limits = true;
+    }
 
-      if (joint_limits_interface::getSoftJointLimits(urdf_joint, soft_limits)) has_soft_limits = true;
+    if (joint_limits_interface::getSoftJointLimits(urdf_joint, soft_limits))
+    {
+      has_soft_limits = true;
     }
   }
-
-  if (!has_limits) return;
+  if (!has_limits)
+  {
+    return;
+  }
 
   if (limits.has_position_limits)
   {
-    *lower_limit = limits.min_position;
-    *upper_limit = limits.max_position;
+    lower_limit = limits.min_position;
+    upper_limit = limits.max_position;
   }
 
-  if (limits.has_effort_limits) *effort_limit = limits.max_effort;
+  if (limits.has_effort_limits)
+  {
+    effort_limit = limits.max_effort;
+  }
 
   if (has_soft_limits)
   {
@@ -212,7 +204,6 @@ void IIWA_HW::registerJointLimits(const std::string& joint_name, const hardware_
 bool IIWA_HW::read(ros::Duration period)
 {
   ros::Duration delta = ros::Time::now() - timer_;
-
   static bool was_connected = false;
 
   if (iiwa_ros_conn_.getRobotIsConnected())
@@ -228,24 +219,28 @@ bool IIWA_HW::read(ros::Duration period)
     // if there is no controller active the robot goes to zero position
     if (!was_connected)
     {
-      for (int j = 0; j < IIWA_JOINTS; j++) device_->joint_position_command[j] = device_->joint_position[j];
-
+      for (int j = 0; j < IIWA_JOINTS; j++)
+      {
+        device_->joint_position_command[j] = device_->joint_position[j];
+      }
       was_connected = true;
     }
 
     for (int j = 0; j < IIWA_JOINTS; j++)
+    {
       device_->joint_velocity[j] =
           filters::exponentialSmoothing((device_->joint_position[j] - device_->joint_position_prev[j]) / period.toSec(),
                                         device_->joint_velocity[j], 0.2);
+    }
 
-    return 1;
+    return true;
   }
   else if (delta.toSec() >= 10)
   {
     ROS_INFO("No LBR IIWA is connected. Waiting for the robot to connect before reading ...");
     timer_ = ros::Time::now();
   }
-  return 0;
+  return false;
 }
 
 bool IIWA_HW::write(ros::Duration period)
@@ -261,11 +256,13 @@ bool IIWA_HW::write(ros::Duration period)
   if (iiwa_ros_conn_.getRobotIsConnected())
   {
     // Joint Position Control
-    if (interface_ == interface_type_.at(0))
+    if (interface_ == interface_type_[0])
     {
-      if (device_->joint_position_command ==
-          last_joint_position_command_)  // avoid sending the same joint command over and over
+      // Avoid sending the same joint command over and over
+      if (device_->joint_position_command == last_joint_position_command_)
+      {
         return 0;
+      }
 
       last_joint_position_command_ = device_->joint_position_command;
 
@@ -277,12 +274,12 @@ bool IIWA_HW::write(ros::Duration period)
       iiwa_ros_conn_.setJointPosition(command_joint_position_);
     }
     // Joint Impedance Control
-    else if (interface_ == interface_type_.at(1))
+    else if (interface_ == interface_type_[1])
     {
       // TODO
     }
     // Joint Velocity Control
-    else if (interface_ == interface_type_.at(2))
+    else if (interface_ == interface_type_[2])
     {
       // TODO
     }

--- a/iiwa_moveit/package.xml
+++ b/iiwa_moveit/package.xml
@@ -21,11 +21,12 @@
   <run_depend>velocity_controllers</run_depend>
   <run_depend>effort_controllers</run_depend>
   <run_depend>gazebo_ros_control</run_depend>
+  <run_depend>moveit_ros_planning_interface</run_depend>
+  <run_depend>moveit_ros_warehouse</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>xacro</run_depend>
-  <build_depend>iiwa_description</build_depend>
   <run_depend>iiwa_description</run_depend>
 
   <buildtool_depend>catkin</buildtool_depend>

--- a/iiwa_ros/CMakeLists.txt
+++ b/iiwa_ros/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(iiwa_ros)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++14 ${CMAKE_CXX_FLAGS}")
 
 find_package(catkin REQUIRED COMPONENTS
   iiwa_msgs

--- a/iiwa_ros/CMakeLists.txt
+++ b/iiwa_ros/CMakeLists.txt
@@ -23,13 +23,11 @@ add_library(${PROJECT_NAME}
 	src/iiwa_ros.cpp
 	src/smart_servo_service.cpp
 	src/path_parameters_service.cpp
-    src/path_parameters_lin_service.cpp
+  src/path_parameters_lin_service.cpp
 	src/time_to_destination_service.cpp
 )
 
-target_link_libraries(${PROJECT_NAME}
-    ${catkin_LIBRARIES}
-)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 ## Add dependence to the iiwa_msg module for the library
 add_dependencies(${PROJECT_NAME} iiwa_msgs_generate_messages_cpp)

--- a/iiwa_ros/include/iiwa_ros/conversions.h
+++ b/iiwa_ros/include/iiwa_ros/conversions.h
@@ -35,6 +35,8 @@
 
 namespace iiwa_ros
 {
+namespace conversions
+{
 /**
  * @brief Creates a JointQuantity with the same value in all its components.
  *

--- a/iiwa_ros/include/iiwa_ros/conversions.h
+++ b/iiwa_ros/include/iiwa_ros/conversions.h
@@ -83,6 +83,31 @@ iiwa_msgs::JointQuantity jointQuantityFromDouble(const double a1, const double a
 }
 
 /**
+ * @brief Converts a JointQuantity message to a std::vector of type T
+ * @param quantity: the JointQuantity to convert
+ * @return  std::vector<T>
+ */
+template <typename T>
+std::vector<T> jointQuantityToVector(const iiwa_msgs::JointQuantity& quantity)
+{
+  return std::vector<T>{quantity.a1, quantity.a2, quantity.a3, quantity.a4, quantity.a5, quantity.a6, quantity.a7};
+}
+
+template <typename T>
+iiwa_msgs::JointQuantity jointQuantityFromVector(const std::vector<T>& v)
+{
+  iiwa_msgs::JointQuantity return_value;
+  return_value.a1 = v[0];
+  return_value.a2 = v[1];
+  return_value.a3 = v[2];
+  return_value.a4 = v[3];
+  return_value.a5 = v[4];
+  return_value.a6 = v[5];
+  return_value.a7 = v[6];
+  return return_value;
+}
+
+/**
  * @brief Creates a CartesianQuantity with the same value in all its components.
  *
  * @param value the value to use for all the CartesianQuantity components.
@@ -142,4 +167,5 @@ iiwa_msgs::CartesianQuantity CartesianQuantityFromDouble(const double translatio
   quantity.c = rotation_value;
   return quantity;
 }
-}
+}  // Namespace conversions.
+}  // Namespace iiwa_ros.

--- a/iiwa_ros/include/iiwa_ros/iiwa_ros.h
+++ b/iiwa_ros/include/iiwa_ros/iiwa_ros.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include <ros/ros.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/WrenchStamped.h>
 #include <iiwa_msgs/CartesianVelocity.h>
@@ -43,90 +44,83 @@
 #include <iiwa_ros/path_parameters_lin_service.h>
 #include <iiwa_ros/smart_servo_service.h>
 #include <iiwa_ros/time_to_destination_service.h>
-#include <ros/ros.h>
 #include <std_msgs/Time.h>
 
 #include <mutex>
 #include <string>
+#include <memory>
 
 namespace iiwa_ros
 {
 extern ros::Time last_update_time;
 
 template <typename ROSMSG>
-class iiwaHolder
+class DataHolder
 {
 public:
-  iiwaHolder() : is_new(false)
+  DataHolder() = default;
+  DataHolder(const DataHolder& other)
+    : data_(other.data_)
+    , is_new_(other.is_new_)
   {
   }
-
-  void set_value(const ROSMSG& value)
+  DataHolder(DataHolder&& other) noexcept : data_(other.data_), is_new_(other.is_new_) {}
+  DataHolder& operator=(const DataHolder& rhs)
   {
-    mutex.lock();
-    data = value;
-    is_new = true;
-    mutex.unlock();
+    data_ = rhs.data_;
+    is_new_ = rhs.is_new_;
+  }
+  DataHolder& operator=(DataHolder&& rhs)
+  {
+    data_ = std::move(rhs.data_);
+    is_new_ = std::move(is_new_);
+  }
+  void setValue(const ROSMSG& value)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    data_ = value;
+    is_new_ = true;
   }
 
-  bool get_value(ROSMSG& value)
+  bool getValue(ROSMSG& value)
   {
-    bool was_new = false;
-
-    mutex.lock();
-    value = data;
-    was_new = is_new;
-    is_new = false;
-    mutex.unlock();
-
+    bool was_new{false};
+    std::lock_guard<std::mutex> lock(mutex_);
+    value = data_;
+    was_new = is_new_;
+    is_new_ = false;
     return was_new;
   }
 
-  bool has_new_value()
-  {
-    return is_new;
-  }
-
-  ROSMSG get_value_unsynchronized()
-  {
-    return data;
-  }
-
+  bool newValue() const { return is_new_; }
+  ROSMSG getValueUnsynchronized() const { return data_; }
 private:
-  ROSMSG data;
-  bool is_new;
-  std::mutex mutex;
+  ROSMSG data_;
+  bool is_new_{false};
+  std::mutex mutex_;
 };
 
 template <typename ROSMSG>
 class iiwaStateHolder
 {
 public:
-  void init(const std::string& topic)
+  void init(std::string topic)
   {
     ros::NodeHandle nh;
-    subscriber = nh.subscribe<ROSMSG>(topic, 1, &iiwaStateHolder<ROSMSG>::set, this);
+    subscriber_ = nh.subscribe<ROSMSG>(topic, 1, &iiwaStateHolder<ROSMSG>::set, this);
   }
 
-  bool has_new_value()
-  {
-    return holder.has_new_value();
-  }
-
+  bool newValue() { return holder_.newValue(); }
   void set(ROSMSG value)
   {
     last_update_time = ros::Time::now();
-    holder.set_value(value);
+    holder_.setValue(value);
   }
 
-  bool get(ROSMSG& value)
-  {
-    return holder.get_value(value);
-  }
-
+  bool get(ROSMSG& value) { return holder_.getValue(value); }
 private:
-  iiwaHolder<ROSMSG> holder;
-  ros::Subscriber subscriber;
+  DataHolder<ROSMSG> holder_;
+  ros::Subscriber subscriber_;
 };
 
 template <typename ROSMSG>
@@ -136,38 +130,36 @@ public:
   void init(const std::string& topic)
   {
     ros::NodeHandle nh;
-    publisher = nh.advertise<ROSMSG>(topic, 1);
+    publisher_ = nh.advertise<ROSMSG>(topic, 1);
   }
 
-  void set(const ROSMSG& value)
-  {
-    holder.set_value(value);
-  }
-
-  ROSMSG get()
-  {
-    return holder.get_value_unsynchronized();
-  }
-
+  void set(const ROSMSG& value) { holder_.setValue(value); }
+  ROSMSG get() { return holder_.getValueUnsynchronized(); }
   void publishIfNew()
   {
     static ROSMSG msg;
-    if (publisher.getNumSubscribers() && holder.get_value(msg))
-      publisher.publish(msg);
+    if (publisher_.getNumSubscribers() && holder_.getValue(msg))
+    {
+      publisher_.publish(msg);
+    }
   }
 
 private:
-  ros::Publisher publisher;
-  iiwaHolder<ROSMSG> holder;
+  DataHolder<ROSMSG> holder_;
+  ros::Publisher publisher_;
 };
 
 class iiwaRos
 {
 public:
+  iiwaRos() = default;
+
   /**
-   * @brief Constructor for class iiwaRos holding all the methods to command and get the state of the robot.
+   * This constructor takes the robot name as parameter, this can be used to spawn the publishers/subscribers under the
+   * right namespace. For example: /<robot_name>/state/JointPosition. If the default constructor is used the topics used
+   * will live under the namespace specified when launching the ROS node.
    */
-  iiwaRos();
+  iiwaRos(std::string robot_name);
 
   /**
    * @brief Initializes the necessary topics for state and command methods.
@@ -245,58 +237,42 @@ public:
    *
    * @return iiwa_ros::SmartServoService
    */
-  SmartServoService getSmartServoService()
-  {
-    return smart_servo_service_;
-  }
-
+  SmartServoService getSmartServoService() { return smart_servo_service_; }
   /**
    * @brief Returns the object that allows to call the timeToDestination service.
    *
    * @return iiwa_ros::PathParametersService
    */
-  PathParametersService getPathParametersService()
-  {
-    return path_parameters_service_;
-  }
-
+  PathParametersService getPathParametersService() { return path_parameters_service_; }
   /**
    * @brief Returns the object that allows to call the timeToDestination service.
    *
    * @return iiwa_ros::PathParametersService
    */
-  PathParametersLinService getPathParametersLinService()
-  {
-    return path_parameters_lin_service_;
-  }
-
+  PathParametersLinService getPathParametersLinService() { return path_parameters_lin_service_; }
   /**
    * @brief Returns the object that allows to call the setPathParameters service.
    *
    * @return iiwa_ros::TimeToDestinationService
    */
-  TimeToDestinationService getTimeToDestinationService()
-  {
-    return time_to_destination_service_;
-  };
-
+  TimeToDestinationService getTimeToDestinationService() { return time_to_destination_service_; }
   /**
    * @brief Set the cartesian pose of the robot.
    *
    * @param position the cartesian pose to set the robot.
    * @return void
-   */  
-  void setCartesianPose(const geometry_msgs::PoseStamped& position);
-  
-    /**
-   * @brief Set the cartesian pose of the robot.
-   *
-   * @param position the cartesian pose to set the robot.
-   * @param callback function to be called when the movement is finished.
-   * @return void
    */
+  void setCartesianPose(const geometry_msgs::PoseStamped& position);
+
+  /**
+ * @brief Set the cartesian pose of the robot.
+ *
+ * @param position the cartesian pose to set the robot.
+ * @param callback function to be called when the movement is finished.
+ * @return void
+ */
   void setCartesianPose(const geometry_msgs::PoseStamped& position, std::function<void()> callback);
-  
+
   /**
    * @brief Set the cartesian pose of the robot with a linear movement.
    *
@@ -304,15 +280,15 @@ public:
    * @return void
    */
   void setCartesianPoseLin(const geometry_msgs::PoseStamped& position);
-  
-   /**
-   * @brief Set the cartesian pose of the robot with a linear movement.
-   *
-   * @param position the cartesian pose to set the robot.
-   * @param callback function to be called when the movement is finished.
-   * @return void
-   */
-  void setCartesianPoseLin(const geometry_msgs::PoseStamped& position , std::function<void()> callback);
+
+  /**
+  * @brief Set the cartesian pose of the robot with a linear movement.
+  *
+  * @param position the cartesian pose to set the robot.
+  * @param callback function to be called when the movement is finished.
+  * @return void
+  */
+  void setCartesianPoseLin(const geometry_msgs::PoseStamped& position, std::function<void()> callback);
 
   /**
    * @brief Set the joint position of the robot.
@@ -344,6 +320,9 @@ public:
   bool getRobotIsConnected();
 
 private:
+  std::string robot_name_{""};
+
+  // StateHolders provide subscribers to the robot state.
   iiwaStateHolder<geometry_msgs::PoseStamped> holder_state_pose_;
   iiwaStateHolder<iiwa_msgs::JointPosition> holder_state_joint_position_;
   iiwaStateHolder<iiwa_msgs::JointTorque> holder_state_joint_torque_;
@@ -354,16 +333,20 @@ private:
   iiwaStateHolder<iiwa_msgs::JointPositionVelocity> holder_state_joint_position_velocity_;
   iiwaStateHolder<std_msgs::Time> holder_state_destination_reached_;
 
+  // CommandHolder provide publishers for robot commands.
   iiwaCommandHolder<geometry_msgs::PoseStamped> holder_command_pose_;
   iiwaCommandHolder<geometry_msgs::PoseStamped> holder_command_pose_lin_;
   iiwaCommandHolder<iiwa_msgs::JointPosition> holder_command_joint_position_;
   iiwaCommandHolder<iiwa_msgs::JointVelocity> holder_command_joint_velocity_;
   iiwaCommandHolder<iiwa_msgs::JointPositionVelocity> holder_command_joint_position_velocity_;
 
+  // Services.
   SmartServoService smart_servo_service_;
   PathParametersService path_parameters_service_;
   PathParametersLinService path_parameters_lin_service_;
   TimeToDestinationService time_to_destination_service_;
+
+  // Callback functionalities.
   std::function<void()> callback_;
   void timeToDestinationWatcher();
 };

--- a/iiwa_ros/include/iiwa_ros/iiwa_ros.h
+++ b/iiwa_ros/include/iiwa_ros/iiwa_ros.h
@@ -64,7 +64,11 @@ public:
     , is_new_(other.is_new_)
   {
   }
-  DataHolder(DataHolder&& other) noexcept : data_(other.data_), is_new_(other.is_new_) {}
+  DataHolder(DataHolder&& other) noexcept
+    : data_(other.data_)
+    , is_new_(other.is_new_)
+  {
+  }
   DataHolder& operator=(const DataHolder& rhs)
   {
     data_ = rhs.data_;
@@ -94,6 +98,7 @@ public:
 
   bool newValue() const { return is_new_; }
   ROSMSG getValueUnsynchronized() const { return data_; }
+
 private:
   ROSMSG data_;
   bool is_new_{false};
@@ -118,6 +123,7 @@ public:
   }
 
   bool get(ROSMSG& value) { return holder_.getValue(value); }
+
 private:
   DataHolder<ROSMSG> holder_;
   ros::Subscriber subscriber_;
@@ -265,12 +271,12 @@ public:
   void setCartesianPose(const geometry_msgs::PoseStamped& position);
 
   /**
- * @brief Set the cartesian pose of the robot.
- *
- * @param position the cartesian pose to set the robot.
- * @param callback function to be called when the movement is finished.
- * @return void
- */
+   * @brief Set the cartesian pose of the robot.
+   *
+   * @param position the cartesian pose to set the robot.
+   * @param callback function to be called when the movement is finished.
+   * @return void
+   */
   void setCartesianPose(const geometry_msgs::PoseStamped& position, std::function<void()> callback);
 
   /**
@@ -282,12 +288,12 @@ public:
   void setCartesianPoseLin(const geometry_msgs::PoseStamped& position);
 
   /**
-  * @brief Set the cartesian pose of the robot with a linear movement.
-  *
-  * @param position the cartesian pose to set the robot.
-  * @param callback function to be called when the movement is finished.
-  * @return void
-  */
+   * @brief Set the cartesian pose of the robot with a linear movement.
+   *
+   * @param position the cartesian pose to set the robot.
+   * @param callback function to be called when the movement is finished.
+   * @return void
+   */
   void setCartesianPoseLin(const geometry_msgs::PoseStamped& position, std::function<void()> callback);
 
   /**

--- a/iiwa_ros/include/iiwa_ros/iiwa_services.hpp
+++ b/iiwa_ros/include/iiwa_ros/iiwa_services.hpp
@@ -45,10 +45,7 @@ public:
   /**
    * @brief Creates a ROS Service client for the Service server with the given name.
    */
-  iiwaServices() : service_name_(""), verbose_(true), service_ready_(false)
-  {
-  }
-
+  iiwaServices() {}
   /**
    * @brief Creates a ROS Service client for the Service server with the given name.
    *
@@ -56,7 +53,9 @@ public:
    * @param verbose If true some ROS_INFO messages will be printed out during service calls.
    */
   iiwaServices(const std::string& service_name, const bool verbose = true)
-    : service_name_(service_name), verbose_(verbose), service_ready_(false)
+    : service_name_(service_name)
+    , verbose_(verbose)
+    , service_ready_(false)
   {
     initService();
   }
@@ -72,7 +71,7 @@ public:
     ros::NodeHandle nh_;
     client_ = nh_.serviceClient<T>(service_name_);
     service_ready_ = true;
-  };
+  }
 
   /**
    * @brief Sets the name of the ROS Service serve to connect to. Use initService to create a Service client to a
@@ -82,28 +81,20 @@ public:
   {
     service_name_ = service_name;
     initService();
-  };
+  }
 
   /**
    * @brief Sets the verbosity level.
    * If true some ROS_INFO messages will be printed out during service calls.
    */
-  virtual void setVerbosity(const bool verbose)
-  {
-    verbose_ = verbose;
-  }
-
+  virtual void setVerbosity(const bool verbose) { verbose_ = verbose; }
   /**
    * @brief Returns the error string obtained from the last service call that produced an error.
    * Available only if the implementation of the service call produces a string error in case of failure.
    *
    * @return std::string
    */
-  virtual std::string getLastError()
-  {
-    return service_error_;
-  }
-
+  virtual std::string getLastError() const { return service_error_; }
 protected:
   /**
    * @brief Implements the actuall call to the service
@@ -112,11 +103,11 @@ protected:
    */
   virtual bool callService() = 0;
 
-  std::string service_name_ = "";
+  std::string service_name_{""};
   ros::ServiceClient client_;
   T config_;
-  bool verbose_ = true;
-  std::string service_error_;
-  bool service_ready_;
+  bool verbose_{true};
+  std::string service_error_{""};
+  bool service_ready_{false};
 };
 }

--- a/iiwa_ros/include/iiwa_ros/iiwa_services.hpp
+++ b/iiwa_ros/include/iiwa_ros/iiwa_services.hpp
@@ -95,6 +95,7 @@ public:
    * @return std::string
    */
   virtual std::string getLastError() const { return service_error_; }
+
 protected:
   /**
    * @brief Implements the actuall call to the service

--- a/iiwa_ros/include/iiwa_ros/path_parameters_lin_service.h
+++ b/iiwa_ros/include/iiwa_ros/path_parameters_lin_service.h
@@ -38,7 +38,7 @@ namespace iiwa_ros
 class PathParametersLinService : public iiwaServices<iiwa_msgs::SetPathParametersLin>
 {
 public:
-  PathParametersLinService();
+  PathParametersLinService() = default;
 
   /**
    * @brief ...

--- a/iiwa_ros/include/iiwa_ros/path_parameters_service.h
+++ b/iiwa_ros/include/iiwa_ros/path_parameters_service.h
@@ -38,7 +38,7 @@ namespace iiwa_ros
 class PathParametersService : public iiwaServices<iiwa_msgs::SetPathParameters>
 {
 public:
-  PathParametersService();
+  PathParametersService() = default;
 
   /**
    * @brief ...

--- a/iiwa_ros/include/iiwa_ros/smart_servo_service.h
+++ b/iiwa_ros/include/iiwa_ros/smart_servo_service.h
@@ -44,7 +44,7 @@ namespace iiwa_ros
 class SmartServoService : public iiwaServices<iiwa_msgs::ConfigureSmartServo>
 {
 public:
-  SmartServoService();
+  SmartServoService() = default;
 
   /**
    * @brief Creates a Service client given the name of the configureSmartServo service: e.g.

--- a/iiwa_ros/include/iiwa_ros/time_to_destination_service.h
+++ b/iiwa_ros/include/iiwa_ros/time_to_destination_service.h
@@ -47,7 +47,7 @@ namespace iiwa_ros
 class TimeToDestinationService : public iiwaServices<iiwa_msgs::TimeToDestination>
 {
 public:
-  TimeToDestinationService();
+  TimeToDestinationService() = default;
 
   /**
    * @brief Creates a Service client given the name of the timeToDestination service: e.g.
@@ -71,6 +71,6 @@ protected:
   virtual bool callService();
 
 private:
-  double time_to_destination_;
+  double time_to_destination_{0.0};
 };
 }

--- a/iiwa_ros/src/iiwa_ros.cpp
+++ b/iiwa_ros/src/iiwa_ros.cpp
@@ -31,39 +31,44 @@
 #include "iiwa_ros/iiwa_ros.h"
 #include <thread>
 
-
 using namespace std;
 
 namespace iiwa_ros
 {
 ros::Time last_update_time;
 
-iiwaRos::iiwaRos()
+iiwaRos::iiwaRos(std::string robot_name)
+  : robot_name_(robot_name)
 {
 }
 
 void iiwaRos::init()
 {
-  holder_state_pose_.init("state/CartesianPose");
-  holder_state_joint_position_.init("state/JointPosition");
-  holder_state_joint_torque_.init("state/JointTorque");
-  holder_state_wrench_.init("state/CartesianWrench");
-  holder_state_joint_stiffness_.init("state/JointStiffness");
-  holder_state_joint_position_velocity_.init("state/JointPositionVelocity");
-  holder_state_joint_damping_.init("state/JointDamping");
-  holder_state_joint_velocity_.init("state/JointVelocity");
-  holder_state_destination_reached_.init("state/DestinationReached");
+  std::string robot_namespace{""};
+  if (!robot_name_.empty())
+  {
+    robot_namespace = "/" + robot_name_;
+  }
+  holder_state_pose_.init(robot_namespace + "state/CartesianPose");
+  holder_state_joint_position_.init(robot_namespace + "state/JointPosition");
+  holder_state_joint_torque_.init(robot_namespace + "state/JointTorque");
+  holder_state_wrench_.init(robot_namespace + "state/CartesianWrench");
+  holder_state_joint_stiffness_.init(robot_namespace + "state/JointStiffness");
+  holder_state_joint_position_velocity_.init(robot_namespace + "state/JointPositionVelocity");
+  holder_state_joint_damping_.init(robot_namespace + "state/JointDamping");
+  holder_state_joint_velocity_.init(robot_namespace + "state/JointVelocity");
+  holder_state_destination_reached_.init(robot_namespace + "state/DestinationReached");
 
-  holder_command_pose_.init("command/CartesianPose");
-  holder_command_pose_lin_.init("command/CartesianPoseLin");
-  holder_command_joint_position_.init("command/JointPosition");
-  holder_command_joint_position_velocity_.init("command/JointPositionVelocity");
-  holder_command_joint_velocity_.init("command/JointVelocity");
+  holder_command_pose_.init(robot_namespace + "command/CartesianPose");
+  holder_command_pose_lin_.init(robot_namespace + "command/CartesianPoseLin");
+  holder_command_joint_position_.init(robot_namespace + "command/JointPosition");
+  holder_command_joint_position_velocity_.init(robot_namespace + "command/JointPositionVelocity");
+  holder_command_joint_velocity_.init(robot_namespace + "command/JointVelocity");
 
-  smart_servo_service_.setServiceName("configuration/configureSmartServo");
-  path_parameters_service_.setServiceName("configuration/pathParameters");
-  path_parameters_lin_service_.setServiceName("configuration/pathParametersLin");
-  time_to_destination_service_.setServiceName("state/timeToDestination");
+  smart_servo_service_.setServiceName(robot_namespace + "configuration/configureSmartServo");
+  path_parameters_service_.setServiceName(robot_namespace + "configuration/pathParameters");
+  path_parameters_lin_service_.setServiceName(robot_namespace + "configuration/pathParametersLin");
+  time_to_destination_service_.setServiceName(robot_namespace + "state/timeToDestination");
 }
 
 bool iiwaRos::getRobotIsConnected()
@@ -125,7 +130,7 @@ void iiwaRos::setCartesianPoseLin(const geometry_msgs::PoseStamped& position)
   holder_command_pose_lin_.publishIfNew();
 }
 
-void iiwaRos::setCartesianPoseLin(const geometry_msgs::PoseStamped& position , std::function<void()> callback)
+void iiwaRos::setCartesianPoseLin(const geometry_msgs::PoseStamped& position, std::function<void()> callback)
 {
   setCartesianPoseLin(position);
   callback_ = callback;
@@ -150,25 +155,26 @@ void iiwaRos::setJointPositionVelocity(const iiwa_msgs::JointPositionVelocity& v
 }
 
 void iiwaRos::timeToDestinationWatcher()
-{	 
-  bool flag = false;
-  sleep(0.5);
-  for(;;)
+{
+  bool flag{false}, alive{true};
+  ros::Duration(0.5).sleep();
+
+  while (alive)
   {
-    if(time_to_destination_service_.getTimeToDestination() > 0)
+    if (time_to_destination_service_.getTimeToDestination() > 0)
     {
-      if(flag == false)
+      if (!flag)
       {
-	flag = true;
+        flag = true;
       }
     }
-    else  
+    else
     {
-      if(flag == true)
-      { 				
-	callback_();
-	return;
-      }   
+      if (flag)
+      {
+        callback_();
+        alive = false;
+      }
     }
   }
 }

--- a/iiwa_ros/src/path_parameters_lin_service.cpp
+++ b/iiwa_ros/src/path_parameters_lin_service.cpp
@@ -32,10 +32,6 @@
 
 namespace iiwa_ros
 {
-PathParametersLinService::PathParametersLinService() : iiwaServices<iiwa_msgs::SetPathParametersLin>()
-{
-}
-
 PathParametersLinService::PathParametersLinService(const std::string& service_name, const bool verbose)
   : iiwaServices<iiwa_msgs::SetPathParametersLin>(service_name, verbose)
 {
@@ -75,5 +71,4 @@ bool PathParametersLinService::setMaxCartesianVelocity(const geometry_msgs::Twis
 {
   setPathParametersLin(max_cartesian_velocity);
 }
-
 }

--- a/iiwa_ros/src/path_parameters_service.cpp
+++ b/iiwa_ros/src/path_parameters_service.cpp
@@ -32,10 +32,6 @@
 
 namespace iiwa_ros
 {
-PathParametersService::PathParametersService() : iiwaServices<iiwa_msgs::SetPathParameters>()
-{
-}
-
 PathParametersService::PathParametersService(const std::string& service_name, const bool verbose)
   : iiwaServices<iiwa_msgs::SetPathParameters>(service_name, verbose)
 {

--- a/iiwa_ros/src/smart_servo_service.cpp
+++ b/iiwa_ros/src/smart_servo_service.cpp
@@ -34,10 +34,6 @@
 
 namespace iiwa_ros
 {
-SmartServoService::SmartServoService() : iiwaServices<iiwa_msgs::ConfigureSmartServo>()
-{
-}
-
 SmartServoService::SmartServoService(const std::string& service_name, const bool verbose)
   : iiwaServices<iiwa_msgs::ConfigureSmartServo>(service_name, verbose)
 {
@@ -147,7 +143,8 @@ bool SmartServoService::setJointImpedanceMode(const iiwa_msgs::JointQuantity& jo
 
 bool SmartServoService::setJointImpedanceMode(const double joint_stiffnes, const double joint_damping)
 {
-  setJointImpedanceMode(jointQuantityFromDouble(joint_stiffnes), jointQuantityFromDouble(joint_damping));
+  setJointImpedanceMode(conversions::jointQuantityFromDouble(joint_stiffnes),
+                        conversions::jointQuantityFromDouble(joint_damping));
 }
 
 bool SmartServoService::setCartesianImpedanceMode(const iiwa_msgs::CartesianQuantity& cartesian_stiffness,
@@ -168,15 +165,16 @@ bool SmartServoService::setCartesianImpedanceMode(const iiwa_msgs::CartesianQuan
                                                   const double nullspace_stiffness, const double nullspace_damping)
 {
   setCartesianImpedanceMode(cartesian_stiffness, cartesian_damping, nullspace_stiffness, nullspace_damping,
-                            CartesianQuantityFromDouble(-1), CartesianQuantityFromDouble(-1),
-                            CartesianQuantityFromDouble(-1), false);
+                            conversions::CartesianQuantityFromDouble(-1), conversions::CartesianQuantityFromDouble(-1),
+                            conversions::CartesianQuantityFromDouble(-1), false);
 }
 
 bool SmartServoService::setCartesianImpedanceMode(const iiwa_msgs::CartesianQuantity& cartesian_stiffness,
                                                   const iiwa_msgs::CartesianQuantity& cartesian_damping)
 {
-  setCartesianImpedanceMode(cartesian_stiffness, cartesian_damping, -1, -1, CartesianQuantityFromDouble(-1),
-                            CartesianQuantityFromDouble(-1), CartesianQuantityFromDouble(-1), false);
+  setCartesianImpedanceMode(cartesian_stiffness, cartesian_damping, -1, -1,
+                            conversions::CartesianQuantityFromDouble(-1), conversions::CartesianQuantityFromDouble(-1),
+                            conversions::CartesianQuantityFromDouble(-1), false);
 }
 
 bool SmartServoService::setCartesianImpedanceMode(const iiwa_msgs::CartesianQuantity& cartesian_stiffness,
@@ -205,8 +203,9 @@ bool SmartServoService::setDesiredForceMode(const int cartesian_dof, const doubl
 bool SmartServoService::setDesiredForceMode(const int cartesian_dof, const double desired_force,
                                             const double desired_stiffness)
 {
-  setDesiredForceMode(cartesian_dof, desired_force, desired_stiffness, CartesianQuantityFromDouble(-1),
-                      CartesianQuantityFromDouble(-1), CartesianQuantityFromDouble(-1), false);
+  setDesiredForceMode(cartesian_dof, desired_force, desired_stiffness, conversions::CartesianQuantityFromDouble(-1),
+                      conversions::CartesianQuantityFromDouble(-1), conversions::CartesianQuantityFromDouble(-1),
+                      false);
 }
 
 bool SmartServoService::setSinePatternmode(const int cartesian_dof, const double frequency, const double amplitude,
@@ -224,7 +223,7 @@ bool SmartServoService::setSinePatternmode(const int cartesian_dof, const double
 bool SmartServoService::setSinePatternmode(const int cartesian_dof, const double frequency, const double amplitude,
                                            const double stiffness)
 {
-  setSinePatternmode(cartesian_dof, frequency, amplitude, stiffness, CartesianQuantityFromDouble(-1),
-                     CartesianQuantityFromDouble(-1), CartesianQuantityFromDouble(-1), false);
+  setSinePatternmode(cartesian_dof, frequency, amplitude, stiffness, conversions::CartesianQuantityFromDouble(-1),
+                     conversions::CartesianQuantityFromDouble(-1), conversions::CartesianQuantityFromDouble(-1), false);
 }
 }

--- a/iiwa_ros/src/time_to_destination_service.cpp
+++ b/iiwa_ros/src/time_to_destination_service.cpp
@@ -32,10 +32,6 @@
 
 namespace iiwa_ros
 {
-TimeToDestinationService::TimeToDestinationService() : iiwaServices<iiwa_msgs::TimeToDestination>()
-{
-}
-
 TimeToDestinationService::TimeToDestinationService(const std::string& service_name, const bool verbose)
   : iiwaServices<iiwa_msgs::TimeToDestination>(service_name, verbose)
 {
@@ -63,7 +59,7 @@ bool TimeToDestinationService::callService()
   {
     if (verbose_)
     {
-        ROS_DEBUG_STREAM(ros::this_node::getName() << ": " << service_name_ << " successfully called.");
+      ROS_DEBUG_STREAM(ros::this_node::getName() << ": " << service_name_ << " successfully called.");
     }
     time_to_destination_ = config_.response.remaining_time;
     return true;

--- a/iiwa_ros_java/src/de/tum/in/camp/kuka/ros/Configuration.java
+++ b/iiwa_ros_java/src/de/tum/in/camp/kuka/ros/Configuration.java
@@ -23,21 +23,18 @@
 
 package de.tum.in.camp.kuka.ros;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 
+import org.apache.commons.lang.NullArgumentException;
 import org.ros.exception.ParameterNotFoundException;
 import org.ros.namespace.GraphName;
 import org.ros.node.AbstractNodeMain;
@@ -54,21 +51,13 @@ import com.kuka.roboticsAPI.uiModel.userKeys.IUserKeyListener;
 import com.kuka.roboticsAPI.uiModel.userKeys.UserKeyAlignment;
 import com.kuka.roboticsAPI.uiModel.userKeys.UserKeyEvent;
 
+import de.tum.in.camp.kuka.ros.configuration.FileBasedConfigurationProviderFactory;
+import de.tum.in.camp.kuka.ros.configuration.IConfigurationProvider;
+
 /**
  * Utility class to get configuration at startup from the config.txt file or from ROS params in the ROS param server.
  */
 public class Configuration extends AbstractNodeMain {
-
-	// Name to use to build the name of the ROS topics
-	private static Map<String, String> config;
-	private static String robotName;
-	private static String masterIp;
-	private static String masterPort;
-	private static String masterUri; //< IP address of ROS core to talk to.
-	private static String robotIp;
-	private static boolean staticConfigurationSuccessful;
-	private static boolean ntpWithHost;
-	
 	private TimeProvider timeProvider;
 	private ScheduledExecutorService ntpExecutorService = null;
 
@@ -77,97 +66,92 @@ public class Configuration extends AbstractNodeMain {
 
 	// It is used to wait until we are connected to the ROS master and params are available
 	private Semaphore initSemaphore = new Semaphore(0);
+	
+	private static IConfigurationProvider configurationProvider;
+	
+	/**
+	 * Sets the used configuration provider.
+	 * 
+	 * @param configProvider
+	 */
+	public static void setConfigurationProvider(IConfigurationProvider configProvider) {
+		if (configProvider == null) {
+			throw new NullArgumentException("configProvider");
+		}
 
-	public Configuration() {
-		checkConfiguration();
+		configurationProvider = configProvider;
+		
+		System.out.println("New configuration provider set.");
+		System.out.println("Robot name: " + configurationProvider.getRobotName());
+		System.out.println("Robot IP: " + configurationProvider.getRobotIP());
+		System.out.println("ROS Master URI: " + configurationProvider.getRosMasterUri());
 	}
-
+	
+	/**
+	 * Returns the current set configuration provider.
+	 * 
+	 * @return configuration provider
+	 */
+	public static IConfigurationProvider getConfigurationProvider() {
+		return configurationProvider;
+	}
+	
+	/**
+	 * Checks if a configuration provider is set.
+	 * If not, a new configuration provider based on the config.txt file is created.
+	 */
 	public static void checkConfiguration() {
-		if (!staticConfigurationSuccessful) {
-			configure();
-			if (!staticConfigurationSuccessful) {
-				throw new RuntimeException("Static configuration was not successful");
+		if (configurationProvider == null) {
+			IConfigurationProvider cp;
+			try {
+				cp = FileBasedConfigurationProviderFactory.createFromDefaultConfigFile();
+			} catch (IOException e) {
+				throw new RuntimeException("Static configuration was not successful", e);
 			}
+			
+			setConfigurationProvider(cp);
 		}
-	}
-
-	private static void parseConfigFile() {
-		config = new HashMap<String, String>();
-		BufferedReader br = new BufferedReader(new InputStreamReader(Configuration.class.getResourceAsStream("config.txt")));
-		try {
-			String line = null;
-			while((line = br.readLine()) != null) {
-				String[] lineComponents = line.split(":");
-				if (lineComponents.length != 2)
-					continue;
-
-				config.put(lineComponents[0].trim(), lineComponents[1].trim());
-			}
-		} catch (IOException e2) {
-			e2.printStackTrace();
-		}
-	}
-
-	private static void configure() {
-		parseConfigFile(); //TODO : use KUKA's process data?
-
-		// Obtain name of the robot from config file
-		robotName = config.get("robot_name");
-		System.out.println("Robot name: " + robotName);
-		robotIp = config.get("robot_ip");
-		System.out.println("IP from configuration: " + robotIp); // automatic discovery not reliable with x66
-
-		// Obtain if NTP server is used from config file
-		ntpWithHost  = config.get("ntp_with_host").equals("true");
-
-		// Obtain IP:port of the ROS Master 
-		masterIp = config.get("master_ip");
-		masterPort = config.get("master_port");
-		masterUri = "http://" + masterIp + ":" + masterPort;
-		System.out.println("Master URI: " + masterUri);
-
-		staticConfigurationSuccessful = true;
 	}
 
 	/**
-	 * Get the ROS Master URI, obtained from the configuration file.
+	 * Get the ROS Master URI, obtained from the configuration provider.
 	 * Format : http://IP:port
 	 * 
 	 * @return ROS Master URI
 	 */
 	public static String getMasterURI() {
 		checkConfiguration();
-		return masterUri;
+		return configurationProvider.getRosMasterUri();
 	}
 
 	/**
-	 * Get the ROS Master IP address, obtained from the configuration file.
+	 * Get the ROS Master IP address, obtained from the configuration provider.
 	 * 
 	 * @return ROS Master IP address
 	 */
 	public static String getMasterIp() {
 		checkConfiguration();
-		return masterIp;
+		return configurationProvider.getRosMasterIP();
 	}
 
 	/**
-	 * Get the robot IP address, obtained from the configuration file.
+	 * Get the robot IP address, obtained from the configuration provider.
 	 * 
 	 * @return Robot IP address
 	 */
 	public static String getRobotIp() {
 		checkConfiguration();
-		return robotIp;
+		return configurationProvider.getRobotIP();
 	}
 
 	/**
-	 * Get the robot name, obtained from the configuration file.
+	 * Get the robot name, obtained from the configuration provider.
 	 * 
 	 * @return name of the robot
 	 */
 	public static String getRobotName() {
 		checkConfiguration();
-		return robotName;
+		return configurationProvider.getRobotName();
 	}
 
 	/**
@@ -177,7 +161,7 @@ public class Configuration extends AbstractNodeMain {
 	 */
 	public static boolean getShouldUseNtp() {
 		checkConfiguration();
-		return ntpWithHost;
+		return configurationProvider.getNtpWithHost();
 	}
 
 	/**
@@ -185,7 +169,7 @@ public class Configuration extends AbstractNodeMain {
 	 */
 	@Override
 	public GraphName getDefaultNodeName() {
-		return GraphName.of(robotName + "/configuration");
+		return GraphName.of(getRobotName() + "/configuration");
 	}
 
 	/**
@@ -270,6 +254,7 @@ public class Configuration extends AbstractNodeMain {
 	public TimeProvider getTimeProvider() {
 		if (timeProvider == null)
 			setupTimeProvider();
+		
 		return timeProvider;
 	}
 
@@ -278,21 +263,17 @@ public class Configuration extends AbstractNodeMain {
 	 * 
 	 * @return the configured time provider
 	 */
-	private TimeProvider setupTimeProvider() {
-		checkConfiguration();
-		if (ntpWithHost) {
+	private void setupTimeProvider() {
+		if (getShouldUseNtp()) {
 			try {
 				ntpExecutorService = Executors.newScheduledThreadPool(1);
-				NtpTimeProvider provider = new NtpTimeProvider(InetAddress.getByName(masterIp), ntpExecutorService);
-				timeProvider = provider;
+				timeProvider = new NtpTimeProvider(InetAddress.getByName(getMasterIp()), ntpExecutorService);
 			} catch (UnknownHostException e) {
 				System.err.println("Could not setup NTP time provider!");
 			}
 		} else {
 			timeProvider = new  WallTimeProvider();
 		}
-
-		return timeProvider;
 	}
 
 	/**
@@ -419,7 +400,7 @@ public class Configuration extends AbstractNodeMain {
 		params = getParameterTree();
 		Double ret = null;
 		try {
-			ret = params.getDouble(robotName + "/" + argname);			
+			ret = params.getDouble(getRobotName() + "/" + argname);			
 		} catch (ParameterNotFoundException e) {
 		}
 
@@ -435,7 +416,7 @@ public class Configuration extends AbstractNodeMain {
 		params = getParameterTree();
 		Boolean ret = null;
 		try {
-			ret = params.getBoolean(robotName + "/" + argname);			
+			ret = params.getBoolean(getRobotName() + "/" + argname);			
 		} catch (ParameterNotFoundException e) {
 		}
 
@@ -451,7 +432,7 @@ public class Configuration extends AbstractNodeMain {
 		params = getParameterTree();
 		String ret = null;
 		try {
-			ret = params.getString(robotName + "/" + argname);			
+			ret = params.getString(getRobotName() + "/" + argname);			
 		} catch (ParameterNotFoundException e) {
 		}
 
@@ -467,7 +448,7 @@ public class Configuration extends AbstractNodeMain {
 		List<?> args = new LinkedList<String>();  // supports remove
 		params = getParameterTree();
 		try {
-			args = params.getList(robotName + "/" + argname);
+			args = params.getList(getRobotName() + "/" + argname);
 			if (args == null) {
 				return null;
 			}
@@ -478,8 +459,7 @@ public class Configuration extends AbstractNodeMain {
 	}
 	
 	public void cleanup() {
-		if (ntpWithHost) {
-			
+		if (getShouldUseNtp()) {
 			try {
 				((NtpTimeProvider) timeProvider).stopPeriodicUpdates();
 			} catch (NullPointerException e) {

--- a/iiwa_ros_java/src/de/tum/in/camp/kuka/ros/Motions.java
+++ b/iiwa_ros_java/src/de/tum/in/camp/kuka/ros/Motions.java
@@ -7,6 +7,8 @@ import com.kuka.roboticsAPI.deviceModel.LBR;
 import com.kuka.roboticsAPI.geometricModel.Frame;
 import com.kuka.roboticsAPI.geometricModel.ObjectFrame;
 
+import geometry_msgs.PoseStamped;
+
 public class Motions {
 
 	private LBR robot;

--- a/iiwa_ros_java/src/de/tum/in/camp/kuka/ros/app/ROSBaseApplication.java
+++ b/iiwa_ros_java/src/de/tum/in/camp/kuka/ros/app/ROSBaseApplication.java
@@ -23,6 +23,7 @@
 
 package de.tum.in.camp.kuka.ros.app;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +50,8 @@ import de.tum.in.camp.kuka.ros.ControlModeHandler;
 import de.tum.in.camp.kuka.ros.GoalReachedEventListener;
 import de.tum.in.camp.kuka.ros.Configuration;
 import de.tum.in.camp.kuka.ros.iiwaPublisher;
+import de.tum.in.camp.kuka.ros.configuration.FileBasedConfigurationProviderFactory;
+import de.tum.in.camp.kuka.ros.configuration.IConfigurationProvider;
 import de.tum.in.camp.kuka.ros.Logger;
 
 /*
@@ -102,12 +105,28 @@ public abstract class ROSBaseApplication extends RoboticsAPIApplication {
 	protected int decimationCounter = 0; 
 	protected int controlDecimation = 8;
 
+	/**
+	 * Returns the configuration provider which should be used for the application.
+	 * 
+	 * The base implementation returns a configuration provider using the default config.txt  
+	 * 
+	 * @return Configuration provider
+	 */
+	protected IConfigurationProvider getConfigurationProvider() {
+		try {
+			return FileBasedConfigurationProviderFactory.createFromDefaultConfigFile();
+		} catch (IOException e) {
+			throw new RuntimeException("Could not create default configuration provider.", e);
+		}
+	}
+	
 	public void initialize() {
 		Logger.setSunriseLogger(getLogger());
 		
 		robot = getContext().getDeviceFromType(LBR.class);
 
 		// Standard configuration.
+		Configuration.setConfigurationProvider(getConfigurationProvider());
 		configuration = new Configuration();
 		publisher = new iiwaPublisher(Configuration.getRobotName(), configuration);
 
@@ -165,7 +184,7 @@ public abstract class ROSBaseApplication extends RoboticsAPIApplication {
 
 		initSuccessful = true;  // We cannot throw here.
 	}
-
+	
 	public void run() {
 		if (!initSuccessful) {
 			throw new RuntimeException("Could not init the RoboticApplication successfully");

--- a/iiwa_ros_java/src/de/tum/in/camp/kuka/ros/configuration/FileBasedConfigurationProviderFactory.java
+++ b/iiwa_ros_java/src/de/tum/in/camp/kuka/ros/configuration/FileBasedConfigurationProviderFactory.java
@@ -1,0 +1,100 @@
+/**  
+ * Copyright (C) 2016-2017 Salvatore Virga - salvo.virga@tum.de, Marco Esposito - marco.esposito@tum.de
+ * Technische Universität München
+ * Chair for Computer Aided Medical Procedures and Augmented Reality
+ * Fakultät für Informatik / I16, Boltzmannstraße 3, 85748 Garching bei München, Germany
+ * http://campar.in.tum.de
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, 
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package de.tum.in.camp.kuka.ros.configuration;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+
+import de.tum.in.camp.kuka.ros.Configuration;
+
+public class FileBasedConfigurationProviderFactory {
+	
+	/**
+	 * Parses the config.txt and creates a configuration provider.
+	 * 
+	 * @return Configuration provider filled with values from the config.txt
+	 * @throws IOException
+	 */
+	public static IConfigurationProvider createFromDefaultConfigFile() throws IOException {
+		
+		// The config file is historically located on de/tum/in/camp/kuka/ros/config.txt
+		return create(Configuration.class.getResourceAsStream("config.txt"));
+	}
+	
+	/**
+	 * Parses the content of the input stream and creates a configuration provider.
+	 * 
+	 * @param s
+	 * @return Configuration provider filled with values from the given input stream
+	 * @throws IOException
+	 */
+	public static IConfigurationProvider create(InputStream s) throws IOException {
+		if (s == null) {
+			throw new NullPointerException("s");
+		}
+		
+		Map<String, String> config = read(s);
+		
+		// Obtain name of the robot from config file
+		String robotName = config.get("robot_name");
+		String robotIp = config.get("robot_ip");
+		
+		// Obtain if NTP server is used from config file
+		boolean ntpWithHost  = config.get("ntp_with_host").equals("true");
+
+		// Obtain IP:port of the ROS Master 
+		String masterIp = config.get("master_ip");
+		int masterPort = Integer.parseInt(config.get("master_port"));
+
+		StaticConfigurationProvider configProvider = new StaticConfigurationProvider(robotName, robotIp, masterIp, masterPort, ntpWithHost);
+
+		return configProvider;
+	}
+	
+	/**
+	 * Parses the key value pairs stored in the config.
+	 * 
+	 * @return Key-Value pairs
+	 * @throws IOException if the stream could not be read
+	 */
+	private static HashMap<String, String> read(InputStream s) throws IOException {
+		HashMap<String, String> config = new HashMap<String, String>();
+		BufferedReader br = new BufferedReader(new InputStreamReader(s));
+		
+		String line = null;
+		while((line = br.readLine()) != null) {
+			String[] lineComponents = line.split(":");
+			if (lineComponents.length != 2)
+				continue;
+
+			config.put(lineComponents[0].trim(), lineComponents[1].trim());
+		}
+		
+		return config;
+	}
+}

--- a/iiwa_ros_java/src/de/tum/in/camp/kuka/ros/configuration/IConfigurationProvider.java
+++ b/iiwa_ros_java/src/de/tum/in/camp/kuka/ros/configuration/IConfigurationProvider.java
@@ -1,0 +1,69 @@
+/**  
+ * Copyright (C) 2018 Guido Breitenhuber - guido.breitenhuber@joanneum.at, Thomas Haspl - thomas.haspl@joanneum.at
+ * JOANNEUM RESEARCH Forschungsgesellschaft mbH
+ * ROBOTICS – Institute for Robotics and Mechatronics
+ * Lakeside B08a, 9020 Klagenfurt am Wörthersee, Austria
+ * http://www.joanneum.at/robotics
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, 
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package de.tum.in.camp.kuka.ros.configuration;
+
+
+public interface IConfigurationProvider {
+	/**
+	 * Get the robot name.
+	 * 
+	 * @return name of the robot
+	 */
+	public String getRobotName();
+	
+	/**
+	 * Get the robot IP address.
+	 * 
+	 * @return Robot IP address
+	 */
+	public String getRobotIP();
+	
+	/**
+	 * Get the ROS Master IP address.
+	 * 
+	 * @return ROS Master IP address
+	 */
+	public String getRosMasterIP();
+	
+	/**
+	 * Get the ROS Master port number.
+	 * 
+	 * @return ROS Master port number
+	 */
+	public int getRosMasterPort();
+	
+	/**
+	 * Get the ROS Master URI.
+	 * 
+	 * @return ROS Master URI (http://IP:port)
+	 */
+	public String getRosMasterUri();
+	
+	/**
+	 * Return if an external NTP server should be used.
+	 * 
+	 * @return true if external NTP server should be used, false otherwise
+	 */
+	public boolean getNtpWithHost();
+}

--- a/iiwa_ros_java/src/de/tum/in/camp/kuka/ros/configuration/ProcessDataConfigurationProvider.java
+++ b/iiwa_ros_java/src/de/tum/in/camp/kuka/ros/configuration/ProcessDataConfigurationProvider.java
@@ -58,8 +58,7 @@ public class ProcessDataConfigurationProvider implements IConfigurationProvider 
 
 	@Override
 	public int getRosMasterPort() {
-		String rosMasterPort = applicationData.getProcessData("rosMasterPort").getValue();
-		return Integer.parseInt(rosMasterPort);
+		return applicationData.getProcessData("rosMasterPort").getValue();
 	}
 
 	@Override

--- a/iiwa_ros_java/src/de/tum/in/camp/kuka/ros/configuration/ProcessDataConfigurationProvider.java
+++ b/iiwa_ros_java/src/de/tum/in/camp/kuka/ros/configuration/ProcessDataConfigurationProvider.java
@@ -23,69 +23,53 @@
 
 package de.tum.in.camp.kuka.ros.configuration;
 
+import com.kuka.roboticsAPI.applicationModel.IApplicationData;
+
+import de.tum.in.camp.kuka.ros.configuration.IConfigurationProvider;
+
 /**
- * Configuration provider using values provided in the constructor.
+ * Configuration Provider using the KUKA application process data.
  * 
- * @author Guido Breitenhuber
+ * @author Thomas Haspl
  */
-public class StaticConfigurationProvider implements IConfigurationProvider {
-
-	private String robotName;
-	private String robotIp;
-	private boolean ntpWithHost;
-	private String masterIp;
-	private int masterPort;
-	private String masterUri;
-
-	public StaticConfigurationProvider(String robotName, String robotIp, String masterIp, int masterPort, boolean ntpWithHost)
+public class ProcessDataConfigurationProvider implements IConfigurationProvider {
+	
+	private IApplicationData applicationData;
+	
+	public ProcessDataConfigurationProvider (IApplicationData applicationData)
 	{
-		throwIfStringNullOrEmpty(robotName, "Robot name");
-		throwIfStringNullOrEmpty(robotIp, "Robot IP");
-		throwIfStringNullOrEmpty(masterIp, "ROS master IP");
-				
-		this.robotName = robotName;
-		this.robotIp = robotIp;
-		this.ntpWithHost = ntpWithHost;
-		
-		this.masterIp = masterIp;
-		this.masterPort = masterPort;
-		this.masterUri = "http://" + masterIp + ":" + masterPort;
+		this.applicationData = applicationData;
 	}
-	
-	public static void throwIfStringNullOrEmpty(final String s, final String paramName) {
-		if (s == null || s.trim().isEmpty()) {
-			throw new IllegalArgumentException(paramName + " must not be null or empty");
-		}
-	}
-	
+
 	@Override
 	public String getRobotName() {
-		return robotName;
+		return applicationData.getProcessData("robotName").getValue();
 	}
 
 	@Override
 	public String getRobotIP() {
-		return robotIp;
+		return applicationData.getProcessData("robotIp").getValue();
 	}
 
 	@Override
 	public String getRosMasterIP() {
-		return masterIp;
+		return applicationData.getProcessData("rosMasterIp").getValue();
 	}
 
 	@Override
 	public int getRosMasterPort() {
-		return masterPort;
-	}
-
-	@Override
-	public boolean getNtpWithHost() {
-		return ntpWithHost;
+		String rosMasterPort = applicationData.getProcessData("rosMasterPort").getValue();
+		return Integer.parseInt(rosMasterPort);
 	}
 
 	@Override
 	public String getRosMasterUri() {
-		return masterUri;
+		return "http://" + this.getRosMasterIP() + ":" + this.getRosMasterPort();
+	}
+
+	@Override
+	public boolean getNtpWithHost() {
+		return applicationData.getProcessData("ntpWithHost").getValue();
 	}
 
 }

--- a/iiwa_ros_java/src/de/tum/in/camp/kuka/ros/configuration/StaticConfigurationProvider.java
+++ b/iiwa_ros_java/src/de/tum/in/camp/kuka/ros/configuration/StaticConfigurationProvider.java
@@ -1,0 +1,87 @@
+/**  
+ * Copyright (C) 2018 Guido Breitenhuber - guido.breitenhuber@joanneum.at, Thomas Haspl - thomas.haspl@joanneum.at
+ * JOANNEUM RESEARCH Forschungsgesellschaft mbH
+ * ROBOTICS – Institute for Robotics and Mechatronics
+ * Lakeside B08a, 9020 Klagenfurt am Wörthersee, Austria
+ * http://www.joanneum.at/robotics
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, 
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package de.tum.in.camp.kuka.ros.configuration;
+
+
+public class StaticConfigurationProvider implements IConfigurationProvider {
+
+	private String robotName;
+	private String robotIp;
+	private boolean ntpWithHost;
+	private String masterIp;
+	private int masterPort;
+	private String masterUri;
+
+	public StaticConfigurationProvider(String robotName, String robotIp, String masterIp, int masterPort, boolean ntpWithHost)
+	{
+		throwIfStringNullOrEmpty(robotName, "Robot name");
+		throwIfStringNullOrEmpty(robotIp, "Robot IP");
+		throwIfStringNullOrEmpty(masterIp, "ROS master IP");
+				
+		this.robotName = robotName;
+		this.robotIp = robotIp;
+		this.ntpWithHost = ntpWithHost;
+		
+		this.masterIp = masterIp;
+		this.masterPort = masterPort;
+		this.masterUri = "http://" + masterIp + ":" + masterPort;
+	}
+	
+	public static void throwIfStringNullOrEmpty(final String s, final String paramName) {
+		if (s == null || s.trim().isEmpty()) {
+			throw new IllegalArgumentException(paramName + " must not be null or empty");
+		}
+	}
+	
+	@Override
+	public String getRobotName() {
+		return robotName;
+	}
+
+	@Override
+	public String getRobotIP() {
+		return robotIp;
+	}
+
+	@Override
+	public String getRosMasterIP() {
+		return masterIp;
+	}
+
+	@Override
+	public int getRosMasterPort() {
+		return masterPort;
+	}
+
+	@Override
+	public boolean getNtpWithHost() {
+		return ntpWithHost;
+	}
+
+	@Override
+	public String getRosMasterUri() {
+		return masterUri;
+	}
+
+}


### PR DESCRIPTION
We made some refactorings to the configuration process for supporting configuration using the Teach Pendant. 

To guarantee backwards compatibility the default configuration pipeline is still using the config.txt.
We extracted an `IConfigurationProvider` interface which decorates the underlying configuration values. `ROSBaseApplication` now creates a config file based configuration provider in the `getConfigurationProvider()` method. This can be overridden in subclasses with custom implementations.

The `ProcessDataConfigurationProvider` class supports configuration using the teach pendant (see discussion #119). Using the `ProcessDataConfigurationProvider` one can override the `getConfigurationProvider()` method in the Robot application and add the following parameters in the `RoboticsAPI.data.xml`

```Java
@Override
protected IConfigurationProvider getConfigurationProvider() {
    return new ProcessDataConfigurationProvider(getApplicationData());
}
```

```xml
<processDataContainer>
    <processData displayName="Robot Name" dataType="java.lang.String" defaultValue="iiwa" id="robotName" value="iiwa"/>
    <processData displayName="Robot IP" dataType="java.lang.String" defaultValue="172.31.1.147" id="robotIp" value="172.31.1.147"/>
    <processData displayName="ROS Master IP" dataType="java.lang.String" defaultValue="172.31.1.100" id="rosMasterIp" value="172.31.1.100"/>
    <processData displayName="ROS Master Port" dataType="java.lang.Integer" defaultValue="11311" id="rosMasterPort" min="0" max="65535" value="11311"/>
    <processData displayName="NTP with Host" dataType="java.lang.Boolean" defaultValue="false" id="ntpWithHost"  value="false"/>
</processDataContainer>
```

We tested the implementation with Sunrise 1.11.