### PR TITLE
fix URDF xacro files following the URDF conventions

### DIFF
--- a/iiwa_description/urdf/iiwa.transmission.xacro
+++ b/iiwa_description/urdf/iiwa.transmission.xacro
@@ -3,85 +3,71 @@
   <xacro:macro name="iiwa_transmission" params="hardware_interface">
 
     <transmission name="${robot_name}_tran_1">
-      <robotNamespace>/${robot_name}</robotNamespace>
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${robot_name}_joint_1">
         <hardwareInterface>hardware_interface/${hardware_interface}</hardwareInterface>
       </joint>
       <actuator name="${robot_name}_motor_1">
-        <hardwareInterface>hardware_interface/${hardware_interface}</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>
 
     <transmission name="${robot_name}_tran_2">
-      <robotNamespace>/${robot_name}</robotNamespace>
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${robot_name}_joint_2">
         <hardwareInterface>hardware_interface/${hardware_interface}</hardwareInterface>
       </joint>
       <actuator name="${robot_name}_motor_2">
-        <hardwareInterface>hardware_interface/${hardware_interface}</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>
 
     <transmission name="${robot_name}_tran_3">
-      <robotNamespace>/${robot_name}</robotNamespace>
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${robot_name}_joint_3">
         <hardwareInterface>hardware_interface/${hardware_interface}</hardwareInterface>
       </joint>
       <actuator name="${robot_name}_motor_3">
-        <hardwareInterface>hardware_interface/${hardware_interface}</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>
 
     <transmission name="${robot_name}_tran_4">
-      <robotNamespace>/${robot_name}</robotNamespace>
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${robot_name}_joint_4">
         <hardwareInterface>hardware_interface/${hardware_interface}</hardwareInterface>
       </joint>
       <actuator name="${robot_name}_motor_4">
-        <hardwareInterface>hardware_interface/${hardware_interface}</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>
 
     <transmission name="${robot_name}_tran_5">
-      <robotNamespace>/${robot_name}</robotNamespace>
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${robot_name}_joint_5">
         <hardwareInterface>hardware_interface/${hardware_interface}</hardwareInterface>
       </joint>
       <actuator name="${robot_name}_motor_5">
-        <hardwareInterface>hardware_interface/${hardware_interface}</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>
 
     <transmission name="${robot_name}_tran_6">
-      <robotNamespace>/${robot_name}</robotNamespace>
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${robot_name}_joint_6">
         <hardwareInterface>hardware_interface/${hardware_interface}</hardwareInterface>
       </joint>
       <actuator name="${robot_name}_motor_6">
-        <hardwareInterface>hardware_interface/${hardware_interface}</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>
 
     <transmission name="${robot_name}_tran_7">
-      <robotNamespace>/${robot_name}</robotNamespace>
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${robot_name}_joint_7">
         <hardwareInterface>hardware_interface/${hardware_interface}</hardwareInterface>
       </joint>
       <actuator name="${robot_name}_motor_7">
-        <hardwareInterface>hardware_interface/${hardware_interface}</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>

--- a/iiwa_description/urdf/iiwa14.xacro
+++ b/iiwa_description/urdf/iiwa14.xacro
@@ -44,15 +44,14 @@
         <geometry>
           <mesh filename="package://iiwa_description/meshes/iiwa14/collision/link_0.stl"/>
         </geometry>
-        <material name="Grey"/>
       </collision>
       
-      <self_collision_checking>
+      <!-- <self_collision_checking>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
           <capsule radius="0.15" length="0.25"/>
         </geometry>
-      </self_collision_checking>
+      </self_collision_checking> -->
       
     </link>
     
@@ -91,7 +90,6 @@
         <geometry>
           <mesh filename="package://iiwa_description/meshes/iiwa14/collision/link_1.stl"/>
         </geometry>
-        <material name="Orange"/>
       </collision>
     </link>
     
@@ -130,7 +128,6 @@
         <geometry>
           <mesh filename="package://iiwa_description/meshes/iiwa14/collision/link_2.stl"/>
         </geometry>
-        <material name="Orange"/>
       </collision>
     </link>
     
@@ -169,7 +166,6 @@
         <geometry>
           <mesh filename="package://iiwa_description/meshes/iiwa14/collision/link_3.stl"/>
         </geometry>
-        <material name="Orange"/>
       </collision>
     </link>
     
@@ -208,7 +204,6 @@
         <geometry>
           <mesh filename="package://iiwa_description/meshes/iiwa14/collision/link_4.stl"/>
         </geometry>
-        <material name="Orange"/>
       </collision>
     </link>
     
@@ -247,7 +242,6 @@
         <geometry>
           <mesh filename="package://iiwa_description/meshes/iiwa14/collision/link_5.stl"/>
         </geometry>
-        <material name="Orange"/>
       </collision>
     </link>
     
@@ -286,7 +280,6 @@
         <geometry>
           <mesh filename="package://iiwa_description/meshes/iiwa14/collision/link_6.stl"/>
         </geometry>
-        <material name="Orange"/>
       </collision>
     </link>
     
@@ -325,7 +318,6 @@
         <geometry>
           <mesh filename="package://iiwa_description/meshes/iiwa14/collision/link_7.stl"/>
         </geometry>
-        <material name="Grey"/>
       </collision>
     </link>
     

--- a/iiwa_description/urdf/iiwa7.xacro
+++ b/iiwa_description/urdf/iiwa7.xacro
@@ -44,15 +44,14 @@
         <geometry>
           <mesh filename="package://iiwa_description/meshes/iiwa7/collision/link_0.stl"/>
         </geometry>
-        <material name="Grey"/>
       </collision>
       
-      <self_collision_checking>
+      <!-- <self_collision_checking>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
           <capsule radius="0.15" length="0.25"/>
         </geometry>
-      </self_collision_checking>
+      </self_collision_checking> -->
       
     </link>
     
@@ -89,7 +88,6 @@
         <geometry>
           <mesh filename="package://iiwa_description/meshes/iiwa7/collision/link_1.stl"/>
         </geometry>
-        <material name="Orange"/>
       </collision>
     </link>
     
@@ -126,7 +124,6 @@
         <geometry>
           <mesh filename="package://iiwa_description/meshes/iiwa7/collision/link_2.stl"/>
         </geometry>
-        <material name="Orange"/>
       </collision>
     </link>
     
@@ -164,7 +161,6 @@
         <geometry>
           <mesh filename="package://iiwa_description/meshes/iiwa7/collision/link_3.stl"/>
         </geometry>
-        <material name="Orange"/>
       </collision>
       
     </link>
@@ -203,7 +199,6 @@
         <geometry>
           <mesh filename="package://iiwa_description/meshes/iiwa7/collision/link_4.stl"/>
         </geometry>
-        <material name="Orange"/>
       </collision>
     </link>
     
@@ -241,7 +236,6 @@
         <geometry>
           <mesh filename="package://iiwa_description/meshes/iiwa7/collision/link_5.stl"/>
         </geometry>
-        <material name="Orange"/>
       </collision>
     </link>
     
@@ -279,7 +273,6 @@
         <geometry>
           <mesh filename="package://iiwa_description/meshes/iiwa7/collision/link_6.stl"/>
         </geometry>
-        <material name="Orange"/>
       </collision>
     </link>
     
@@ -317,7 +310,6 @@
         <geometry>
           <mesh filename="package://iiwa_description/meshes/iiwa7/collision/link_7.stl"/>
         </geometry>
-        <material name="Grey"/>
       </collision>
     </link>
     


### PR DESCRIPTION
upload the URDF to ROS parameter server

```sh
roslaunch iiwa_description iiwa7_upload.launch
```

run the following test script `test.py`

```py
#!/usr/bin/env python

import kdl_parser_py.urdf
from urdf_parser_py.urdf import URDF
from kdl_parser_py.urdf import treeFromUrdfModel
import rospy


def main():

    robot_description = URDF.from_parameter_server()

    (ok, tree) = treeFromUrdfModel(robot_description) # get KDL tree from URDF
    chain = tree.getChain("world", "iiwa_link_7") # get KDL chain from kdl tree

    print("Number of segments is: {}".format(chain.getNrOfSegments()))


if __name__ == "__main__":
    main()
```

we will get the following warnings about URDF:

```sh
Unknown tag: material
Unknown tag: self_collision_checking
Unknown tag: material
Unknown tag: material
Unknown tag: material
Unknown tag: material
Unknown tag: material
Unknown tag: material
Unknown tag: material
Unknown tag: hardwareInterface
Unknown tag: robotNamespace
Unknown tag: hardwareInterface
Unknown tag: robotNamespace
Unknown tag: hardwareInterface
Unknown tag: robotNamespace
Unknown tag: hardwareInterface
Unknown tag: robotNamespace
Unknown tag: hardwareInterface
Unknown tag: robotNamespace
Unknown tag: hardwareInterface
Unknown tag: robotNamespace
Unknown tag: hardwareInterface
Unknown tag: robotNamespace
Number of segments is: 8
```